### PR TITLE
Add a unit test for the 'FX55' opcode

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -3,8 +3,10 @@ pub const DISPLAY_WIDTH: usize = 64;
 /// The height of the display in pixels
 pub const DISPLAY_HEIGHT: usize = 32;
 /// The size of ram in bytes
-pub const RAM_SIZE: usize = 4096;
+pub const RAM_SIZE: u16 = 4096;
 /// How many cycles the cpu advances for every frame. This decides how fast the cpu will run
 pub const CYCLES_PER_FRAME: usize = 5;
 /// For the regular chip 8 roms
 pub const ROM_START_ADDRESS: u16 = 0x200;
+/// Amount of registers CHIP-8 has
+pub const NUM_REGISTERS: u8 = 16;

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -355,7 +355,7 @@ impl Cpu {
 
                 //move over all rows of the sprite (it has n rows)
                 for sprite_row in 0..n as usize {
-                    if sprite_start + sprite_row >= RAM_SIZE {
+                    if sprite_start + sprite_row >= RAM_SIZE as usize {
                         return;
                     }
                     let sprite = self.memory.bytes[sprite_start + sprite_row]; //bytes[sprite_start + sprite_row];
@@ -541,6 +541,7 @@ impl Cpu {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::constants::NUM_REGISTERS;
 
     #[test]
     fn it_can_initialize() {
@@ -977,8 +978,31 @@ mod tests {
     #[test]
     fn executes_Fx55() {
         // - LD [I], Vx
-        //Stores V0 to VX in memory starting at address I. I is then set to I + x + 1.
-        //let mut instance = Cpu::new(RomBuffer::from_bytes(vec![0xF0, 0x55]));
+        //Stores V0 to VX in memory starting at address I. I is not changed.
+        let register_value = 0xFF;
+        for x in 0..16 {
+            for index_register_value in 0..RAM_SIZE - x {
+                let mut instance = Cpu::new(RomBuffer::from_bytes(vec![(x | 0xF0) as u8, 0x55]));
+                // Fill registers with the expected values
+                for register in 0..NUM_REGISTERS {
+                    instance.registers.set_register(register, register_value);
+                }
+                instance.registers.set_index_register(index_register_value);
+
+                // Run the emulator to see the effect
+                instance.cycle();
+
+                // Check if every byte inside RAM corresponds to the expected value
+                for offset in 0..x {
+                    assert!(
+                        instance.memory.get_byte(index_register_value + offset) == register_value
+                    );
+                }
+
+                // Check if VI changed
+                assert!(instance.registers.get_index_register() == index_register_value)
+            }
+        }
     }
 
     // - LD Vx, [I]

--- a/src/ram.rs
+++ b/src/ram.rs
@@ -8,13 +8,13 @@ use crate::constants::RAM_SIZE;
 ///0xfff end of chip8 ram
 #[derive(Debug, Copy, Clone)]
 pub struct Ram {
-    pub bytes: [u8; RAM_SIZE],
+    pub bytes: [u8; RAM_SIZE as usize],
 }
 impl Ram {
     /// Returns the ram with the fontset already loaded
     pub fn with_fonts() -> Self {
         let mut ram = Self {
-            bytes: [0; RAM_SIZE],
+            bytes: [0; RAM_SIZE as usize],
         };
         // The fontset
         // This is basically a collection of bytes that make up numbers when written out in binary.

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -1,7 +1,9 @@
+use crate::constants::NUM_REGISTERS;
+
 #[derive(Clone, Copy, Default)]
 ///# Holds all the registers and the sound and delay timers
 pub struct Registers {
-    register: [u8; 16],
+    register: [u8; NUM_REGISTERS as usize],
     vindex: u16,
     /// 0 by default, unless its set to a number then it will just start decrementing by one 60 times per
     /// second


### PR DESCRIPTION
## What has been done

This PR adds a unit test, which covers the `FX55` opcode. Additionally, this PR changes a type of the `RAM_SIZE` constant to avoid unnecessary casts and introduces a new constant `NUM_REGISTERS`, which holds the amount of registers that the emulator has.