### PR TITLE
added convenience methods to cpu and rombuffer

### DIFF
--- a/src/rombuffer.rs
+++ b/src/rombuffer.rs
@@ -16,6 +16,20 @@ impl RomBuffer {
         RomBuffer { buffer: bytes }
     }
 }
+impl TryFrom<&str> for RomBuffer {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match std::fs::read(value) {
+            Ok(buffer) => {
+                Ok(RomBuffer { buffer })
+            },
+            Err(msg) => {
+                Err("it didn't work :(")
+            },
+        }
+    }
+}
+
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
A couple of variables are renamed in tests to improve readability in cpu.rs
Methods related to pressing and releasing a key in cpu.rs have been made public so that they can be interacted with externally 
rombuffer has received a tryFrom<&str> method, so that users no longer have to interact with it, this is since rombuffer should be an implementation detail, not for that reason is not relevant to users