### PR TITLE
Fix get_opcode to combine bytes into u16

### DIFF
--- a/src/ram.rs
+++ b/src/ram.rs
@@ -62,7 +62,7 @@ impl Ram {
     }
 
     pub fn get_opcode(self, index: u16) -> u16 {
-        u16::from(self.bytes[index as usize]) | u16::from(self.bytes[(index + 1) as usize])
+          ((self.bytes[index as usize] as u16) << 8) | self.bytes[(index + 1) as usize] as u16
     }
 
     pub fn set(&mut self, index: u16, value: u8) {


### PR DESCRIPTION
Fix the get_opcode method to correctly combine bytes into a u16 value.