### PR TITLE
changes cargo test and run behavior

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ edition = "2024"
 chippie-gui = { path = "./crates/chippie-gui", version = "0.1.0" }
 
 [workspace]
+members = [
+    "crates/*",
+]
 default-members = [
     ".",
-    "crates/chippie-emulator",
-    "crates/chippie-gui",
+    "crates/*",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ edition = "2024"
 chippie-gui = { path = "./crates/chippie-gui", version = "0.1.0" }
 
 [workspace]
-members = [
+default-members = [
+    ".",
     "crates/chippie-emulator",
     "crates/chippie-gui",
 ]

--- a/crates/chippie-gui/src/lib.rs
+++ b/crates/chippie-gui/src/lib.rs
@@ -32,7 +32,7 @@ impl Application {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// use chippie_gui::Application;
     ///
     /// let _ = Application::run();


### PR DESCRIPTION
Ignores a doctest that causes the app to launch when tests are called adds both the current workspace and subcrates to default-members, to make sure tests are ran for subcrates, but root crate is still run when cargo test and cargo run are called