### PR TITLE
Add 'pause' and 'resume' options to the emulator

### DIFF
--- a/crates/chippie-emulator/src/cpu.rs
+++ b/crates/chippie-emulator/src/cpu.rs
@@ -351,30 +351,36 @@ impl Cpu {
     }
 
     /// Creates a new cpu object, with the contents of a rom file loaded in to memory
-    pub fn new(rom: &RomBuffer, framebuffer: Rc<RefCell<Framebuffer>>) -> Self {
-        let program_counter = ROM_START_ADDRESS;
-        let registers = Registers::default();
-        let keyboard = [false; 16];
-        let quirks = Quirks::default();
-        let rng = ChaCha8Rng::seed_from_u64(2);
-        let mut memory = Ram::with_fonts();
-
-        for (x, y) in rom.contents().iter().enumerate() {
-            memory.set(ROM_START_ADDRESS + x as u16, *y);
-        }
-
-        let stack = Stack::default();
-
+    pub fn new(framebuffer: Rc<RefCell<Framebuffer>>) -> Self {
         Self {
             framebuffer,
-            program_counter,
-            registers,
-            keyboard,
-            quirks,
-            rng,
-            memory,
-            stack,
+            program_counter: ROM_START_ADDRESS,
+            registers: Registers::default(),
+            keyboard: [false; 16],
+            quirks: Quirks::default(),
+            rng: ChaCha8Rng::seed_from_u64(2),
+            memory: Ram::with_fonts(),
+            stack: Stack::default(),
             stackpointer: 0,
+        }
+    }
+
+    /// Resets the state of the CPU
+    pub fn reset(&mut self) {
+        // Clean the framebuffer
+        *self.framebuffer.borrow_mut() = [[false; DISPLAY_WIDTH as usize]; DISPLAY_HEIGHT as usize];
+
+        self.program_counter = ROM_START_ADDRESS;
+        self.registers = Registers::default();
+        self.keyboard = [false; 16];
+        self.stack = Stack::default();
+        self.stackpointer = 0;
+    }
+
+    /// Loads content of ROM into RAM and allows program execution
+    pub fn load(&mut self, rom: &RomBuffer) {
+        for (x, y) in rom.contents().iter().enumerate() {
+            self.memory.set(ROM_START_ADDRESS + x as u16, *y);
         }
     }
 }
@@ -393,15 +399,16 @@ mod tests {
 
     #[test]
     fn it_can_initialize() {
-        let buffer = RomBuffer::new("assets/1-chip8-logo.8o");
-        let cpu = Cpu::new(&buffer, create_framebuffer());
+        let cpu = Cpu::new(create_framebuffer());
         assert!(cpu.program_counter == ROM_START_ADDRESS);
     }
 
     #[test]
     fn it_can_fetch_instruction() {
         let buffer = RomBuffer::new("assets/1-chip8-logo.8o");
-        let cpu = Cpu::new(&buffer, create_framebuffer());
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&buffer);
+
         assert!(cpu.fetch() == 0x2320);
     }
 
@@ -409,10 +416,8 @@ mod tests {
     #[test]
     fn executes_00E0() {
         // Clears the framebuffer
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x00, 0xE0]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x00, 0xE0]));
         cpu.framebuffer.borrow_mut()[0][0] = true;
         cpu.cycle();
         assert!(!cpu.framebuffer.borrow()[0][0]);
@@ -422,10 +427,8 @@ mod tests {
     fn executes_00EE() {
         // Return from a subroutine
         // sets the counter to the address at the top of the stack, and subtracts 1 from the stack pointer
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x00, 0xEE]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x00, 0xEE]));
         cpu.stack.set(0, 0x201);
         cpu.stackpointer = 1;
         cpu.cycle();
@@ -436,10 +439,8 @@ mod tests {
     #[test]
     fn executes_1NNN() {
         // Jumps to location nnn, this should set the program counter to nnn
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x11, 0x23]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x11, 0x23]));
         cpu.cycle();
         assert_eq!(cpu.program_counter, 0x123);
     }
@@ -450,10 +451,8 @@ mod tests {
         // 1. increment the stack pointer
         // 2. put the current program counter at the top of the stack
         // 3. sets the program counter to nnn
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x21, 0x23]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x21, 0x23]));
         cpu.cycle();
         assert!(cpu.stackpointer == 1);
         //In a cycle the program counter gets updated before it is pushed to the stack
@@ -464,17 +463,13 @@ mod tests {
     #[test]
     fn executes_3XKK() {
         //Should increment the program counter by two if  register VX is equal to NN
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x31, 0x00]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x31, 0x00]));
         cpu.cycle();
         assert!(cpu.program_counter == 0x204);
 
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x31, 0x01]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x31, 0x01]));
         cpu.cycle();
         assert!(cpu.program_counter == 0x202);
     }
@@ -482,17 +477,13 @@ mod tests {
     #[test]
     fn executes_4Xkk() {
         //Should increment the program counter by two if  register VX is not equal to NN
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x41, 0x00]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x41, 0x00]));
         cpu.cycle();
         assert!(cpu.program_counter == 0x202);
 
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x41, 0x01]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x41, 0x01]));
         cpu.cycle();
         assert!(cpu.program_counter == 0x204);
     }
@@ -501,18 +492,14 @@ mod tests {
     fn executes_5XY0() {
         //Should increment the program counter by two if register vs equals register vy
         //here regsiter x and y are both 0, which should update the pc to 0x204
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x51, 0x20]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x51, 0x20]));
         cpu.cycle();
         assert!(cpu.program_counter == 0x204);
 
         //Here register 1 will be set to 5, so it should leave the pc at 0x202
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x51, 0x20]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x51, 0x20]));
         cpu.registers.set_register(1, 5);
         cpu.cycle();
         assert!(cpu.program_counter == 0x202);
@@ -521,17 +508,13 @@ mod tests {
     #[test]
     fn executes_6XKK() {
         //Should put the value KK in to register X
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x60, 0x22]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x60, 0x22]));
         cpu.cycle();
         assert!(cpu.registers.get_register(0) == 0x22);
 
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x61, 0x23]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x61, 0x23]));
         cpu.cycle();
         assert!(cpu.registers.get_register(1) == 0x23);
     }
@@ -539,10 +522,8 @@ mod tests {
     #[test]
     fn executes_7XKK() {
         //Should put the value KK plus the current value of register x in to register X
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x71, 0x05]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x71, 0x05]));
         cpu.registers.set_register(0x1, 0x4);
         cpu.cycle();
         assert!(cpu.registers.get_register(1) == 0x09);
@@ -551,10 +532,8 @@ mod tests {
     #[test]
     fn executes_8XY0() {
         //Should store the value of register y in to register x
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x81, 0x20]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x81, 0x20]));
         cpu.registers.set_register(0x2, 0x4);
         cpu.cycle();
         assert!(cpu.registers.get_register(2) == 0x4);
@@ -563,10 +542,8 @@ mod tests {
     #[test]
     fn executes_8XY1() {
         //Should store the value of register y ORED with whatever is in register y in to register x
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x81, 0x21]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x81, 0x21]));
         cpu.registers.set_register(0x2, 4);
         cpu.registers.set_register(0x1, 2);
         cpu.cycle();
@@ -576,10 +553,8 @@ mod tests {
     #[test]
     fn executes_8XY2() {
         //Should store the value of register y ANDed with whatever is in register y in to register x
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x81, 0x22]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x81, 0x22]));
         cpu.registers.set_register(0x2, 4);
         cpu.registers.set_register(0x1, 2);
         cpu.cycle();
@@ -589,10 +564,8 @@ mod tests {
     #[test]
     fn executes_8XY3() {
         //Should store the value of register y XORed with whatever is in register y in to register x
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x81, 0x23]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x81, 0x23]));
         cpu.registers.set_register(0x2, 4);
         cpu.registers.set_register(0x1, 2);
         cpu.cycle();
@@ -604,10 +577,8 @@ mod tests {
         //Should store the value of register y ADDED to whatever is in register y in to register x
         //if the value is bigger than 8 bits (i.e 255), register f should be set to 1, 0 otherwise, and only the lowest
         //8 bit of the result should be kept and stored in register x
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x81, 0x24]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x81, 0x24]));
         cpu.registers.set_register(0x2, 200);
         cpu.registers.set_register(0x1, 1);
         cpu.cycle();
@@ -615,10 +586,8 @@ mod tests {
         assert!(cpu.registers.get_register(1) == (200 + 1));
         assert!(cpu.registers.get_register(0xf) == 0);
 
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x81, 0x24]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x81, 0x24]));
         cpu.registers.set_register(0x2, 200);
         cpu.registers.set_register(0x1, 60);
         cpu.cycle();
@@ -632,20 +601,16 @@ mod tests {
     fn executes_8XY5() {
         //Should store the value of register y subtracted from whatever is in register y in to register x
         //if an underflow occurs, register f is set to 0, otherwise its 1. So the opposite of what you'd expect
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x81, 0x25]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x81, 0x25]));
         cpu.registers.set_register(0x1, 10);
         cpu.registers.set_register(0x2, 5);
         cpu.cycle();
         assert!(cpu.registers.get_register(1) == 10 - 5);
         assert!(cpu.registers.get_register(0xf) == 1);
 
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x81, 0x25]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x81, 0x25]));
         cpu.registers.set_register(0x1, 5);
         cpu.registers.set_register(0x2, 10);
         cpu.cycle();
@@ -658,10 +623,8 @@ mod tests {
         //Should store the value of register x shifted right by one in register x
         //sets register f to 1 if the least significant bit of vx is 1, otherwise it sets it to 0
         //then vx is divided by 2?
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x81, 0x26]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x81, 0x26]));
         cpu.registers.set_register(0x1, 17);
         cpu.cycle();
         assert!(cpu.registers.get_register(1) == 8);
@@ -671,20 +634,16 @@ mod tests {
     fn executes_8XY7() {
         // Should store the value of register x subtracted from the value in register y, inside register x. register f is said when we didn't borrow.
         // again, opposite of what you'd expect.
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x81, 0x27]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x81, 0x27]));
         cpu.registers.set_register(0x1, 2);
         cpu.registers.set_register(0x2, 10);
         cpu.cycle();
         assert!(cpu.registers.get_register(1) == 8);
         assert!(cpu.registers.get_register(0xf) == 1);
 
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x81, 0x27]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x81, 0x27]));
         cpu.registers.set_register(0x1, 10);
         cpu.registers.set_register(0x2, 2);
         cpu.cycle();
@@ -696,10 +655,8 @@ mod tests {
     fn executes_8XYE() {
         // Set register x equal to itself shifted left by one. if msb of x is 1, then set VF. If not,
         // unset it. Afterwards, multiply the value at register x by 2. (not sure if i get that right, shl == multiply by 2)
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0x81, 0x2E]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0x81, 0x2E]));
         //the number 0xff has the most significant bit set to 1, so vf must be set when done
         cpu.registers.set_register(0x1, 0xff);
         cpu.cycle();
@@ -712,10 +669,8 @@ mod tests {
     #[test]
     fn executes_ANNN() {
         // Directly sets the index register to NNN
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0xA1, 0x23]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0xA1, 0x23]));
         cpu.cycle();
         assert!(cpu.registers.get_index_register() == 0x123);
     }
@@ -723,10 +678,8 @@ mod tests {
     #[test]
     fn executes_BNNN() {
         // Directly sets the index register to NNN
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0xB3, 0x00]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0xB3, 0x00]));
         cpu.registers.set_register(0, 0x5);
         cpu.cycle();
         assert!(cpu.program_counter == 0x5 + 0x300);
@@ -736,19 +689,15 @@ mod tests {
     fn executes_CXKK() {
         // Set Vx = random byte AND kk. The interpreter generates a random number from 0 to 255, which is then
         // ANDed with the value kk. The results are stored in Vx. See instruction 8xy2 for more information on AND
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0xC0, 0xff]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0xC0, 0xff]));
         cpu.cycle();
         let random_number = cpu.registers.get_register(0);
         assert_eq!(random_number, 197);
 
         //here the ANDed number is 0, so the result is zero too
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0xC0, 0x00]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0xC0, 0x00]));
         cpu.cycle();
         let random_number = cpu.registers.get_register(0);
         assert_eq!(random_number, 0);
@@ -765,12 +714,10 @@ mod tests {
         //See instruction 8xy3 for more information on XOR, and section 2.4, Display, for more information on the Chip-8 screen and sprites.
 
         //0xD123 should make a 1-byte tall sprite sprite (n == 1), (x == 1 and y == 2)
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![
-                0xD1, 0x21, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff,
-            ]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![
+            0xD1, 0x21, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff,
+        ]));
         //this should set both x and y to 2
         cpu.registers.set_register(1, 2);
         cpu.registers.set_register(2, 2);
@@ -792,10 +739,8 @@ mod tests {
     fn executes_EX9E() {
         // Skip next instruction if key with the value of Vx is pressed. Checks the keyboard, and if the key corresponding
         // to the value of Vx is currently in the down position, PC is increased by 2.
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0xE0, 0x9E]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0xE0, 0x9E]));
         // location will be 0 (since that's default value for register 0)
         cpu.keyboard[0] = true;
         cpu.cycle();
@@ -807,10 +752,8 @@ mod tests {
     fn executes_ExA1() {
         // Skip next instruction if key with the value of Vx is not pressed. Checks the keyboard, and if the key
         // corresponding to the value of Vx is currently in the up position, PC is increased by 2.
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0xE0, 0xA1]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0xE0, 0xA1]));
         cpu.cycle();
         //should be incremented by 4 rather than two if button is not down
         assert!(cpu.program_counter == 0x200 + 4);
@@ -819,10 +762,8 @@ mod tests {
     #[test]
     fn executes_Fx07() {
         //Set Vx = delay timer value. The value of DT is placed into Vx.
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0xF0, 0x07]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0xF0, 0x07]));
         cpu.registers.set_delay_timer(0x10);
         cpu.cycle();
         cpu.decrement_timers();
@@ -834,10 +775,8 @@ mod tests {
     fn executes_Fx0A() {
         //Wait for a key press, store the value of the key in Vx. All execution stops until a key is pressed, then the
         //value of that key is stored in Vx.
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0xF0, 0x0A]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0xF0, 0x0A]));
         cpu.cycle();
         cpu.cycle();
         cpu.cycle();
@@ -849,10 +788,8 @@ mod tests {
     fn executes_Fx15() {
         //- LD DT, Vx
         //Set delay timer = Vx. Delay Timer is set equal to the value of Vx.
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0xf0, 0x15]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0xf0, 0x15]));
         cpu.registers.set_register(0, 125);
         cpu.cycle();
         cpu.decrement_timers();
@@ -866,10 +803,8 @@ mod tests {
     fn executes_Fx18() {
         //- LD ST, Vx
         //Set sound timer = Vx. Sound Timer is set equal to the value of Vx.
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0xf0, 0x18]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0xf0, 0x18]));
         cpu.registers.set_register(0, 125);
         cpu.cycle();
         cpu.decrement_timers();
@@ -883,10 +818,8 @@ mod tests {
     fn executes_Fx1E() {
         // - ADD I, Vx
         //Set I = I + Vx. The values of I and Vx are added, and the results are stored in I.
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0xF6, 0x1E]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0xF6, 0x1E]));
         cpu.registers.set_index_register(0x6);
         cpu.registers.set_register(0x6, 6);
         cpu.cycle();
@@ -899,10 +832,8 @@ mod tests {
         //Set I = location of sprite for digit Vx. The value of I is set to the location for the hexadecimal sprite
         //corresponding to the value of Vx. See section 2.4, Display, for more information on the Chip-8 hexadecimal
         //font. To obtain this value, multiply VX by 5 (all font data stored in first 80 bytes of memory).
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0xF0, 0x29]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0xF0, 0x29]));
         cpu.registers.set_register(0x0, 0x6);
         cpu.cycle();
         assert!(cpu.registers.get_index_register() == 6 * 5);
@@ -914,10 +845,8 @@ mod tests {
         //Store BCD representation of Vx in memory locations I, I+1, and I+2. The interpreter takes the decimal
         //value of Vx, and places the hundreds digit in memory at location in I, the tens digit at location I+1, and
         //the ones digit at location I+2.
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0xF0, 0x33]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0xF0, 0x33]));
         cpu.registers.set_register(0x0, 123);
         cpu.registers.set_index_register(220);
         cpu.cycle();
@@ -933,10 +862,8 @@ mod tests {
         let register_value = 0xFF;
         for x in 0..16 {
             for index_register_value in 0..RAM_SIZE - x {
-                let mut cpu = Cpu::new(
-                    &RomBuffer::from_bytes(vec![(x | 0xF0) as u8, 0x55]),
-                    create_framebuffer(),
-                );
+                let mut cpu = Cpu::new(create_framebuffer());
+                cpu.load(&RomBuffer::from_bytes(vec![(x | 0xF0) as u8, 0x55]));
                 // Fill registers with the expected values
                 for register in 0..NUM_REGISTERS {
                     cpu.registers.set_register(register, register_value);
@@ -961,10 +888,8 @@ mod tests {
     fn executes_Fx65() {
         // - LD Vx, [I]
         //Fills V0 to VX with values from memory starting at address I. I is then set to I + x + 1.
-        let mut cpu = Cpu::new(
-            &RomBuffer::from_bytes(vec![0xF3, 0x65, 0x01, 0x02, 0x03]),
-            create_framebuffer(),
-        );
+        let mut cpu = Cpu::new(create_framebuffer());
+        cpu.load(&RomBuffer::from_bytes(vec![0xF3, 0x65, 0x01, 0x02, 0x03]));
         //sets the index register to point to the 0x01 in the ROM
         cpu.registers.set_index_register(ROM_START_ADDRESS + 2);
         //copies the values 0x01, 0x02 and 0x03 from memory to the registers

--- a/crates/chippie-gui/src/lib.rs
+++ b/crates/chippie-gui/src/lib.rs
@@ -142,11 +142,15 @@ impl Application {
             Message::FileSelected(Some(file)) => {
                 let rom = RomBuffer::new(file.path().to_str().unwrap());
                 self.cpu = Some(Cpu::new(&rom, Rc::clone(&self.framebuffer)));
-                self.running = true;
+                self.resume();
+            }
+            Message::FileSelected(None) => {
+                if self.cpu.is_some() {
+                    self.resume();
+                }
             }
             Message::PauseRequested => self.pause(),
             Message::ResumeRequested => self.resume(),
-            _ => {}
         }
 
         Task::none()

--- a/crates/chippie-gui/src/lib.rs
+++ b/crates/chippie-gui/src/lib.rs
@@ -73,12 +73,20 @@ impl Application {
                 Menu::new(vec![
                     Item::new(
                         button("Resume")
-                            .on_press(Message::ResumeRequested)
+                            .on_press_maybe(if self.cpu.is_some() && !self.running {
+                                Some(Message::ResumeRequested)
+                            } else {
+                                None
+                            })
                             .width(Fill),
                     ),
                     Item::new(
                         button("Pause")
-                            .on_press(Message::PauseRequested)
+                            .on_press_maybe(if self.cpu.is_some() && self.running {
+                                Some(Message::PauseRequested)
+                            } else {
+                                None
+                            })
                             .width(Fill),
                     ),
                 ]),

--- a/crates/chippie-gui/src/lib.rs
+++ b/crates/chippie-gui/src/lib.rs
@@ -140,6 +140,9 @@ impl Application {
                 );
             }
             Message::FileSelected(Some(file)) => {
+                // Clean the framebuffer
+                *self.framebuffer.borrow_mut() = [[false; DISPLAY_WIDTH as usize]; DISPLAY_HEIGHT as usize];
+
                 let rom = RomBuffer::new(file.path().to_str().unwrap());
                 self.cpu = Some(Cpu::new(&rom, Rc::clone(&self.framebuffer)));
                 self.resume();

--- a/crates/chippie-gui/src/lib.rs
+++ b/crates/chippie-gui/src/lib.rs
@@ -83,16 +83,23 @@ impl Application {
                 }
             }
             Message::KeyPressed(key) => {
-                if let Some(i) = Self::to_index(key) {
+                if self.running
+                    && let Some(i) = Self::to_index(key)
+                {
                     self.cpu.set_key_state(i, true)
                 }
             }
             Message::KeyReleased(key) => {
-                if let Some(i) = Self::to_index(key) {
+                if self.running
+                    && let Some(i) = Self::to_index(key)
+                {
                     self.cpu.set_key_state(i, false)
                 }
             }
             Message::FileSelectButtonClicked => {
+                // Pause the execution
+                self.running = false;
+
                 return Task::perform(
                     AsyncFileDialog::new()
                         .add_filter("Chip8 ROM files".to_string(), &["ch8", "8o"])
@@ -108,7 +115,6 @@ impl Application {
                 self.cpu = Cpu::new(&rom, Rc::clone(&framebuffer));
                 self.display =
                     widgets::Display::new(DISPLAY_HEIGHT.into(), DISPLAY_WIDTH.into(), framebuffer);
-
                 self.running = true;
             }
             _ => {}


### PR DESCRIPTION
## What has been done

This PR adds several new options for emulation control. Menu bar entries were added for such options, opened file manager was made to pause program execution.