### PR TITLE
Create features to compile the program for X11 or Wayland

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,4 +19,4 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chip8_emulator"
+name = "chippie"
 version = "0.1.0"
 dependencies = [
  "chippie-gui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +535,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard_x11"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4274ea815e013e0f9f04a2633423e14194e408a0576c943ce3d14ca56c50031c"
+dependencies = [
+ "thiserror 1.0.69",
+ "x11rb",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +705,12 @@ dependencies = [
  "rustc-hash 2.1.1",
  "wgpu",
 ]
+
+[[package]]
+name = "ctor-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f791803201ab277ace03903de1594460708d2d54df6053f2d9e82f592b19e3b"
 
 [[package]]
 name = "cursor-icon"
@@ -982,6 +1004,7 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
@@ -1042,6 +1065,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.2",
+ "windows-link",
 ]
 
 [[package]]
@@ -1958,6 +1991,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2941,6 +2984,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18051cdd562e792cad055119e0cdb2cfc137e44e3987532e0f9659a77931bb08"
 dependencies = [
+ "as-raw-xcb-connection",
  "bytemuck",
  "cfg_aliases",
  "core-graphics 0.24.0",
@@ -2955,12 +2999,14 @@ dependencies = [
  "raw-window-handle",
  "redox_syscall 0.5.18",
  "rustix 0.38.44",
+ "tiny-xlib",
  "wasm-bindgen",
  "wayland-backend",
  "wayland-client",
  "wayland-sys",
  "web-sys",
  "windows-sys 0.59.0",
+ "x11rb",
 ]
 
 [[package]]
@@ -3123,6 +3169,19 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "strict-num",
+]
+
+[[package]]
+name = "tiny-xlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0324504befd01cab6e0c994f34b2ffa257849ee019d3fb3b64fb2c858887d89e"
+dependencies = [
+ "as-raw-xcb-connection",
+ "ctor-lite",
+ "libloading",
+ "pkg-config",
+ "tracing",
 ]
 
 [[package]]
@@ -3755,6 +3814,7 @@ dependencies = [
  "clipboard-win",
  "clipboard_macos",
  "clipboard_wayland",
+ "clipboard_x11",
  "raw-window-handle",
  "thiserror 1.0.69",
 ]
@@ -4175,6 +4235,7 @@ dependencies = [
  "atomic-waker",
  "bitflags 2.10.0",
  "block2 0.5.1",
+ "bytemuck",
  "calloop 0.13.0",
  "cfg_aliases",
  "concurrent-queue",
@@ -4191,6 +4252,7 @@ dependencies = [
  "objc2-foundation 0.2.2",
  "objc2-ui-kit",
  "orbclient",
+ "percent-encoding",
  "pin-project",
  "raw-window-handle",
  "redox_syscall 0.4.1",
@@ -4209,6 +4271,8 @@ dependencies = [
  "web-sys",
  "web-time",
  "windows-sys 0.52.0",
+ "x11-dl",
+ "x11rb",
  "xkbcommon-dl",
 ]
 
@@ -4232,6 +4296,38 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "as-raw-xcb-connection",
+ "gethostname",
+ "libc",
+ "libloading",
+ "once_cell",
+ "rustix 1.1.2",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xcursor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,13 @@ version = "0.1.0"
 authors = ["vancha"]
 edition = "2024"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 chippie-gui = { path = "./crates/chippie-gui", version = "0.1.0" }
+
+[features]
+x11 = ["chippie-gui/x11"]
+wayland = ["chippie-gui/wayland"]
+default = ["wayland"]
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "chip8_emulator"
+name = "chippie"
 version = "0.1.0"
 authors = ["vancha"]
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,18 +5,15 @@ authors = ["vancha"]
 edition = "2024"
 
 [dependencies]
-chippie-gui = { path = "./crates/chippie-gui", version = "0.1.0" }
+chippie-gui = { path = "./crates/chippie-gui", version = "0.1.0", optional = true }
 
 [features]
-x11 = ["chippie-gui/x11"]
-wayland = ["chippie-gui/wayland"]
+x11 = ["dep:chippie-gui", "chippie-gui/x11"]
+wayland = ["dep:chippie-gui", "chippie-gui/wayland"]
 default = ["wayland"]
 
 [workspace]
 members = [
-    "crates/*",
-]
-default-members = [
     ".",
     "crates/*",
 ]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+use std::env;
+
+fn main() {
+    let wayland = env::var_os("CARGO_FEATURE_WAYLAND").is_some();
+    let x11 = env::var_os("CARGO_FEATURE_X11").is_some();
+
+    if !wayland && !x11 {
+        panic!("You must enable at least one of the features: wayland or x11");
+    }
+}

--- a/crates/chippie-gui/Cargo.toml
+++ b/crates/chippie-gui/Cargo.toml
@@ -4,7 +4,11 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-iced = { version = "0.14.0", features = [ "canvas", "linux-theme-detection", "tokio", "wayland", "wgpu" ], default-features = false }
+iced = { version = "0.14.0", features = [ "canvas", "linux-theme-detection", "thread-pool", "tokio" ], default-features = false }
 iced_aw = { version = "0.13.0", features = [ "menu" ] }
 chippie-emulator = { path = "../chippie-emulator" }
 rfd = { version = "0.16.0" }
+
+[features]
+x11 = [ "iced/x11", "iced/tiny-skia" ]
+wayland = [ "iced/wayland", "iced/wgpu" ]


### PR DESCRIPTION
## What has been done

This PR adds several features like `x11` or `wayland`, which control the features of `iced`. They can be used to enable support for different protocols. By default, only  Wayland support is enabled.